### PR TITLE
follow zig-0.14.0

### DIFF
--- a/ext/zig_rb/build.zig
+++ b/ext/zig_rb/build.zig
@@ -6,15 +6,15 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addSharedLibrary(.{ .name = "zig_rb", .root_source_file = .{ .path = "src/main.zig" }, .version = .{ .major = 0, .minor = 0, .patch = 1 }, .optimize = optimize, .target = target });
+    const lib = b.addSharedLibrary(.{ .name = "zig_rb", .root_source_file = b.path("src/main.zig"), .version = .{ .major = 0, .minor = 0, .patch = 1 }, .optimize = optimize, .target = target });
 
     // Ruby stuff
     const ruby_libdir = std.posix.getenv("RUBY_LIBDIR") orelse "";
-    lib.addLibraryPath(.{ .path = ruby_libdir });
+    lib.addLibraryPath(std.Build.LazyPath{ .cwd_relative = ruby_libdir });
     const ruby_hdrdir = std.posix.getenv("RUBY_HDRDIR") orelse "";
-    lib.addIncludePath(.{ .path = ruby_hdrdir });
+    lib.addIncludePath(std.Build.LazyPath{ .cwd_relative = ruby_hdrdir });
     const ruby_archhdrdir = std.posix.getenv("RUBY_ARCHHDRDIR") orelse "";
-    lib.addIncludePath(.{ .path = ruby_archhdrdir });
+    lib.addIncludePath(std.Build.LazyPath{ .cwd_relative = ruby_archhdrdir });
 
     lib.linkSystemLibrary("c");
     b.installArtifact(lib);

--- a/ext/zig_rb/build.zig
+++ b/ext/zig_rb/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const target = b.standardTargetOptions(.{});
@@ -9,11 +9,11 @@ pub fn build(b: *std.build.Builder) void {
     const lib = b.addSharedLibrary(.{ .name = "zig_rb", .root_source_file = .{ .path = "src/main.zig" }, .version = .{ .major = 0, .minor = 0, .patch = 1 }, .optimize = optimize, .target = target });
 
     // Ruby stuff
-    var ruby_libdir = std.os.getenv("RUBY_LIBDIR") orelse "";
+    const ruby_libdir = std.posix.getenv("RUBY_LIBDIR") orelse "";
     lib.addLibraryPath(.{ .path = ruby_libdir });
-    var ruby_hdrdir = std.os.getenv("RUBY_HDRDIR") orelse "";
+    const ruby_hdrdir = std.posix.getenv("RUBY_HDRDIR") orelse "";
     lib.addIncludePath(.{ .path = ruby_hdrdir });
-    var ruby_archhdrdir = std.os.getenv("RUBY_ARCHHDRDIR") orelse "";
+    const ruby_archhdrdir = std.posix.getenv("RUBY_ARCHHDRDIR") orelse "";
     lib.addIncludePath(.{ .path = ruby_archhdrdir });
 
     lib.linkSystemLibrary("c");

--- a/ext/zig_rb/src/main.zig
+++ b/ext/zig_rb/src/main.zig
@@ -29,17 +29,17 @@ fn rb_hundred_doors(...) callconv(.C) ruby.VALUE {
     defer @cVaEnd(&ap);
 
     // first argument is `self`, but we don't use it so we need to discard it
-    var self = @cVaArg(&ap, ruby.VALUE);
+    const self = @cVaArg(&ap, ruby.VALUE);
     _ = self;
 
     // back and forth conversion from Ruby types to internal types + delegation to
     // actual `hundred_doors` function
-    var passes = ruby.NUM2INT(@cVaArg(&ap, ruby.VALUE));
+    const passes = ruby.NUM2INT(@cVaArg(&ap, ruby.VALUE));
     return ruby.INT2NUM(hundred_doors(passes));
 }
 
 export fn Init_libzig_rb() void {
-    var zig_rb_class: ruby.VALUE = ruby.rb_define_class("ZigRb", ruby.rb_cObject);
+    const zig_rb_class: ruby.VALUE = ruby.rb_define_class("ZigRb", ruby.rb_cObject);
     _ = ruby.rb_define_method(zig_rb_class, "hundred_doors", rb_hundred_doors, 1);
 }
 


### PR DESCRIPTION
Thanks for your useful post and this repository.

This pull-request makes this repository runnable on zig-0.14.0 (currently released version).

### tested versions

```console
yuya@yoshiyuki|22:39:22|0|12.10% zig version
0.14.0
yuya@yoshiyuki|22:41:35|0|12.10% ruby -v
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +YJIT +PRISM [x86_64-linux]
```

### before pull-request

<details>

<summary>run "rake benchmark" => build error</summary>

```console
yuya@yoshiyuki|22:41:39|0|12.10% git rev-parse HEAD
621b6188ca89f7cffd525cb741f0a05cd31a32ee
yuya@yoshiyuki|22:42:16|0|12.10% rake benchmark
cd ext/zig_rb
/home/yuya/.local/share/mise/installs/ruby/3.4.3/bin/ruby extconf.rb
make
RUBY_LIBDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/lib RUBY_HDRDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0 RUBY_ARCHHDRDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/x86_64-linux zig build -Doptimize=ReleaseFast
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:16:9: error: local variable is never mutated
    var ruby_archhdrdir = std.os.getenv("RUBY_ARCHHDRDIR") orelse "";
        ^~~~~~~~~~~~~~~
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:16:9: note: consider using 'const'
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:14:9: error: local variable is never mutated
    var ruby_hdrdir = std.os.getenv("RUBY_HDRDIR") orelse "";
        ^~~~~~~~~~~
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:14:9: note: consider using 'const'
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:12:9: error: local variable is never mutated
    var ruby_libdir = std.os.getenv("RUBY_LIBDIR") orelse "";
        ^~~~~~~~~~~
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:12:9: note: consider using 'const'
/home/yuya/src/github.com/katafrakt/zig-ruby/ext/zig_rb/build.zig:3:21: error: root source file struct 'std' has no member named 'build'
pub fn build(b: *std.build.Builder) void {
                 ~~~^~~~~~
/home/yuya/.local/share/mise/installs/zig/0.14.0/lib/std/std.zig:1:1: note: struct declared here
pub const ArrayHashMap = array_hash_map.ArrayHashMap;
^~~
referenced by:
    runBuild__anon_24691: /home/yuya/.local/share/mise/installs/zig/0.14.0/lib/std/Build.zig:2426:50
    main: /home/yuya/.local/share/mise/installs/zig/0.14.0/lib/compiler/build_runner.zig:339:29
    5 reference(s) hidden; use '-freference-trace=7' to see all references
make: *** [Makefile:2: all] Error 2
rake aborted!
Command failed with status (2): [make]
/home/yuya/src/github.com/katafrakt/zig-ruby/Rakefile:4:in 'block (2 levels) in <top (required)>'
/home/yuya/src/github.com/katafrakt/zig-ruby/Rakefile:2:in 'block in <top (required)>'
Tasks: TOP => benchmark => compile_ext
(See full trace by running task with --trace)
```

</details>

### after pull-request

```console
yuya@yoshiyuki|22:43:54|0|12.10% rake benchmark
cd ext/zig_rb
/home/yuya/.local/share/mise/installs/ruby/3.4.3/bin/ruby extconf.rb
make
RUBY_LIBDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/lib RUBY_HDRDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0 RUBY_ARCHHDRDIR=/home/yuya/.local/share/mise/installs/ruby/3.4.3/include/ruby-3.4.0/x86_64-linux zig build -Doptimize=ReleaseFast
cd -
/home/yuya/.local/share/mise/installs/ruby/3.4.3/bin/ruby benchmark.rb
Ruby: 10, Zig: 10
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
                Ruby     1.346k i/100ms
                 Zig   211.201k i/100ms
Calculating -------------------------------------
                Ruby     14.490k (± 5.0%) i/s   (69.01 μs/i) -     72.684k in   5.031102s
                 Zig      2.096M (± 6.8%) i/s  (477.03 ns/i) -     10.560M in   5.062901s

Comparison:
                 Zig:  2096306.1 i/s
                Ruby:    14490.5 i/s - 144.67x  slower
```
